### PR TITLE
disable firefox script timeout / fix for js warnings

### DIFF
--- a/src/core/src/main/resources/sahi/config/ff_profile_template/prefs.js
+++ b/src/core/src/main/resources/sahi/config/ff_profile_template/prefs.js
@@ -145,4 +145,8 @@ user_pref("browser.history_expire_visits", 1);
 user_pref("dom.storage.enabled", true);
 user_pref("places.history.enabled", false);
 user_pref("browser.send_pings", false);
+// disable script timeout / fix for js warnings
+user_pref("dom.max_child_script_run_time", 0);
+user_pref("dom.max_chrome_script_run_time", 0);
+user_pref("dom.max_script_run_time", 0);
 


### PR DESCRIPTION
From time to time our sakuli checks fail with the message "did not complete in 150 seconds. => ERROR " while firefox is showing a warning:

![image](https://cloud.githubusercontent.com/assets/1288215/26486667/568bf27c-41fc-11e7-8503-a0c01b1e100f.png)

This is caused by an internal firefox script timeout (10 seconds default). I would suggest to entirely disable all firefox script timeouts to let sakuli handle them.