### PR TITLE
Add sakuli openshift S2I

### DIFF
--- a/docker/Dockerfile.sakuli.s2i
+++ b/docker/Dockerfile.sakuli.s2i
@@ -1,0 +1,17 @@
+FROM consol/sakuli-centos-xfce
+
+LABEL io.openshift.s2i.scripts-url=image:///opt/sakuli/s2i
+LABEL io.openshift.s2i.destination=/tmp
+
+USER root
+
+COPY s2i/* /opt/sakuli/s2i/
+RUN chmod 775 /opt/sakuli/s2i/*
+
+RUN chmod -R 775 ${SAKULI_TEST_SUITE} && \
+    chgrp -R root ${SAKULI_TEST_SUITE}
+
+USER 1984
+
+ENTRYPOINT []
+CMD ["/opt/sakuli/s2i/usage"]

--- a/docker/openshift/openshift.sakuli.example.dc.run.yaml
+++ b/docker/openshift/openshift.sakuli.example.dc.run.yaml
@@ -10,7 +10,7 @@ metadata:
     version: 1.1.0
   creationTimestamp: null
   name: sakuli-e2e-run-dc
-### template parameter defined via `oc process -f this.yaml -v PARAMETER=value`
+### template parameter defined via `oc process -f this.yaml -p PARAMETER=value`
 parameters:
 - description: The name for the E2E test suite.
   name: E2E_TEST_NAME

--- a/docker/openshift/openshift.sakuli.example.image.build.yaml
+++ b/docker/openshift/openshift.sakuli.example.image.build.yaml
@@ -10,7 +10,7 @@ metadata:
     version: 1.1.0
   creationTimestamp: null
   name: sakuli-e2e-image-build
-### template parameter defined via `oc process -f this.yaml -v PARAMETER=value`
+### template parameter defined via `oc process -f this.yaml -p PARAMETER=value`
 parameters:
 - description: The name for the taged target image
   name: IMAGE

--- a/docker/openshift/openshift.sakuli.example.job.cron.yaml
+++ b/docker/openshift/openshift.sakuli.example.job.cron.yaml
@@ -10,7 +10,7 @@ metadata:
     version: 1.1.0
   creationTimestamp: null
   name: sakuli-e2e-cron-job
-### template parameter defined via `oc process -f this.yaml -v PARAMETER=value`
+### template parameter defined via `oc process -f this.yaml -p PARAMETER=value`
 parameters:
 - description: The name for the E2E test suite.
   name: E2E_TEST_NAME

--- a/docker/openshift/openshift.sakuli.example.job.run.yaml
+++ b/docker/openshift/openshift.sakuli.example.job.run.yaml
@@ -10,7 +10,7 @@ metadata:
     version: 1.1.0
   creationTimestamp: null
   name: sakuli-e2e-run-job
-### template parameter defined via `oc process -f this.yaml -v PARAMETER=value`
+### template parameter defined via `oc process -f this.yaml -p PARAMETER=value`
 parameters:
 - description: The name for the E2E test suite.
   name: E2E_TEST_NAME

--- a/docker/openshift/openshift.sakuli.example.pod.run.yaml
+++ b/docker/openshift/openshift.sakuli.example.pod.run.yaml
@@ -10,7 +10,7 @@ metadata:
     version: 1.1.0
   creationTimestamp: null
   name: sakuli-e2e-run-pod
-### template parameter defined via `oc process -f this.yaml -v PARAMETER=value`
+### template parameter defined via `oc process -f this.yaml -p PARAMETER=value`
 parameters:
 - description: The name for the E2E test suite.
   name: E2E_TEST_NAME

--- a/docker/openshift/openshift.sakuli.gitvolume.pod.run.yaml
+++ b/docker/openshift/openshift.sakuli.gitvolume.pod.run.yaml
@@ -10,7 +10,7 @@ metadata:
     version: 1.1.0
   creationTimestamp: null
   name: sakuli-e2e-run-pod-gitvol
-### template parameter defined via `oc process -f this.yaml -v PARAMETER=value`
+### template parameter defined via `oc process -f this.yaml -p PARAMETER=value`
 parameters:
 - description: The name for the E2E test suite.
   name: E2E_TEST_NAME

--- a/docker/openshift/openshift.sakuli.s2i.build.yaml
+++ b/docker/openshift/openshift.sakuli.s2i.build.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: sakuli-s2i-testsuite-image-build
+metadata:
+  annotations:
+    description: Build config to create a ready to run Sakuli container with the specified testsuite
+    iconClass: icon-beaker
+    tags: consol, sakuli, custom-image, s2i, source-to-image
+    version: 1.1.0
+  creationTimestamp: null
+  name: sakuli-s2i-testsuite-image-build
+### template parameter defined via `oc process -f this.yaml -p "PARAMETER=value"`
+parameters:
+- description: The name for the taged target image
+  name: IMAGE
+  required: true
+  value: sakuli-s2i-testsuite-image
+
+- description: Git source URI for the testsuite
+  name: TESTSUITE_REPOSITORY_URL
+  required: true
+  value: https://github.com/ConSol/sakuli.git
+
+- description: Git branch/tag reference
+  name: TESTSUITE_REPOSITORY_REF
+  value: "master"
+  required: true
+
+- description: Source folder where the test suite is placed
+  name: TESTSUITE_CONTEXT_DIR
+  value: example_test_suites/example_xfce
+  required: true
+
+- description: |-
+    The kind of source to obtain the image from. For more information, please visit
+    https://docs.openshift.com/container-platform/3.7/dev_guide/builds/build_strategies.html#docker-strategy-from
+  name: BASE_IMAGE_KIND
+  required: true
+  value: ImageStream
+
+- description: The name of the base image
+  name: BASE_IMAGE
+  required: true
+  value: sakuli-s2i
+
+- description: GitHub trigger secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET
+  required: true
+
+- description: Generic build trigger secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: GENERIC_WEBHOOK_SECRET
+  required: true
+
+- description: Image tag of the target image
+  name: IMAGE_TAG
+  required: true
+  value: latest
+
+### Configuration of OpenShift objects
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      application: ${IMAGE}
+    name: ${IMAGE}
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      build: ${IMAGE}
+    name: ${IMAGE}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${IMAGE}:${IMAGE_TAG}
+    source:
+      type: Git
+      git:
+        ref: ${TESTSUITE_REPOSITORY_REF}
+        uri: ${TESTSUITE_REPOSITORY_URL}
+      contextDir: ${TESTSUITE_CONTEXT_DIR}
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ${BASE_IMAGE_KIND}
+          name: ${BASE_IMAGE}
+        noCache: false
+        forcePull: true
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - generic:
+        secret: ${GENERIC_WEBHOOK_SECRET}
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+    - type: ConfigChange

--- a/docker/openshift/openshift.sakuli.s2i.build.yaml
+++ b/docker/openshift/openshift.sakuli.s2i.build.yaml
@@ -15,7 +15,7 @@ parameters:
 - description: The name for the taged target image
   name: IMAGE
   required: true
-  value: sakuli-s2i-testsuite-image
+  value: sakuli-s2i-testsuite
 
 - description: Git source URI for the testsuite
   name: TESTSUITE_REPOSITORY_URL

--- a/docker/openshift/openshift.sakuli.s2i.image.build.yaml
+++ b/docker/openshift/openshift.sakuli.s2i.image.build.yaml
@@ -100,7 +100,6 @@ objects:
           kind: ${BASE_IMAGE_KIND}
           name: ${BASE_IMAGE}
         noCache: false
-        forcePull: true
     triggers:
     - github:
         secret: ${GITHUB_WEBHOOK_SECRET}

--- a/docker/openshift/openshift.sakuli.s2i.image.build.yaml
+++ b/docker/openshift/openshift.sakuli.s2i.image.build.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: sakuli-s2i-image-build
+metadata:
+  annotations:
+    description: Sakuli S2I base image
+    iconClass: icon-beaker
+    tags: consol, sakuli, custom-image, s2i, source-to-image
+    version: 1.1.0
+  creationTimestamp: null
+  name: sakuli-s2i-image-build
+### template parameter defined via `oc process -f this.yaml -p "PARAMETER=value"`
+parameters:
+- description: The name for the taged target image
+  name: IMAGE
+  required: true
+  value: sakuli-s2i
+
+- description: Git source URI for application
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/ConSol/sakuli.git
+
+- description: Git branch/tag reference
+  name: SOURCE_REPOSITORY_REF
+  value: "master"
+  required: true
+
+- description: Source Folder where the Dockerfile is placed example `docker`
+  name: SOURCE_DOCKER_CONTEXT_DIR
+  value: docker
+  required: true
+
+- description: Name of the Dockerfile for example Dockerfile.sakuli.ubuntu.xfce
+  name: SOURCE_DOCKERFILE
+  value: Dockerfile.sakuli.s2i
+  required: true
+
+- description: |-
+    The kind of source to obtain the image from. For more information, please visit
+    https://docs.openshift.com/container-platform/3.7/dev_guide/builds/build_strategies.html#docker-strategy-from
+  name: BASE_IMAGE_KIND
+  required: true
+  value: DockerImage
+
+- description: The name of the base image
+  name: BASE_IMAGE
+  required: true
+  value: consol/sakuli-centos-xfce
+
+- description: GitHub trigger secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET
+  required: true
+
+- description: Generic build trigger secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: GENERIC_WEBHOOK_SECRET
+  required: true
+
+- description: Image tag of the target image
+  name: IMAGE_TAG
+  required: true
+  value: latest
+
+### Configuration of OpenShift objects
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      application: ${IMAGE}
+    name: ${IMAGE}
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      build: ${IMAGE}
+    name: ${IMAGE}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${IMAGE}:${IMAGE_TAG}
+    source:
+      type: Git
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      contextDir: ${SOURCE_DOCKER_CONTEXT_DIR}
+    strategy:
+      type: Docker
+      dockerStrategy:
+        dockerfilePath: ${SOURCE_DOCKERFILE}
+        from:
+          kind: ${BASE_IMAGE_KIND}
+          name: ${BASE_IMAGE}
+        noCache: false
+        forcePull: true
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - generic:
+        secret: ${GENERIC_WEBHOOK_SECRET}
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+    - type: ConfigChange

--- a/docker/openshift/openshift.sakuli.s2i.image.build.yaml
+++ b/docker/openshift/openshift.sakuli.s2i.image.build.yaml
@@ -17,7 +17,7 @@ parameters:
   required: true
   value: sakuli-s2i
 
-- description: Git source URI for application
+- description: Git source URI of the s2i project
   name: SOURCE_REPOSITORY_URL
   required: true
   value: https://github.com/ConSol/sakuli.git
@@ -27,12 +27,12 @@ parameters:
   value: "master"
   required: true
 
-- description: Source Folder where the Dockerfile is placed example `docker`
+- description: Source folder where the Dockerfile is placed
   name: SOURCE_DOCKER_CONTEXT_DIR
   value: docker
   required: true
 
-- description: Name of the Dockerfile for example Dockerfile.sakuli.ubuntu.xfce
+- description: Name of the Dockerfile
   name: SOURCE_DOCKERFILE
   value: Dockerfile.sakuli.s2i
   required: true

--- a/docker/s2i/assemble
+++ b/docker/s2i/assemble
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "---> Copy test suite from repo"
+rm -rf ${SAKULI_TEST_SUITE}/*
+cp -fr /tmp/src/* ${SAKULI_TEST_SUITE}
+chmod -R g+rwx ${SAKULI_TEST_SUITE}/*

--- a/docker/s2i/run
+++ b/docker/s2i/run
@@ -1,0 +1,2 @@
+#!/bin/bash
+bash /dockerstartup/startup.sh

--- a/docker/s2i/usage
+++ b/docker/s2i/usage
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cat <<EOF
+This is a S2I base image to run sakuli test suites.
+EOF

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -184,12 +184,12 @@ The values available in the `BASE_IMAGE_KIND` correlate to the values of the `do
 Setup your Sakuli-S2I image.
 [source]
 ----
-oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=sakuli-ubuntu-xfce-s2i" -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce"
+oc process -f openshift.sakuli.s2i.image.build.yaml -p "IMAGE=sakuli-ubuntu-xfce-s2i" -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce" | oc apply -f -
 ----
 Add the test suite of your choice to the S2I image
 [source]
 ----
-oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-customer-workflow" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=http://github.com/SoftwareCompany/SoftwareProduct" -p "TESTSUITE_CONTEXT_DIR=e2e/customer-workflow"
+oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-customer-workflow" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=http://github.com/SoftwareCompany/SoftwareProduct" -p "TESTSUITE_CONTEXT_DIR=e2e/customer-workflow" | oc apply -f -
 ----
 Run your test container `test-customer-workflow`
 

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -143,13 +143,11 @@ Currently OpenShift (Version 3.5) have no different behaviour as Kubernetes itse
 It's possible to use all the features of Sakuli combined with the power of
 https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[OpenShift S2I].
 This empowers you to create s2i base images configured as you desire. The only thing you have to do is to add your test
-suite to the runnable sakuli test environment by configuration. Please find an example
-link:docker/openshift/openshift.sakuli.s2i.image.build.yaml[s2i build config template]
+suite to the runnable sakuli test environment by configuration. Please find an example s2i build config template
 in our template section. This template will provide you a build config and a image stream containing the Sakuli S2I
 image, so that you can easily build up the Sakuli test container for your suites. In addition, we provide a
-link:docker/openshift/openshift.sakuli.s2i.build.yaml[Sakuli test container template]
-to create ready to run Sakuli container, based on Sakuli S2I, using the previously defined S2I image stream, running the
-configured suite.
+Sakuli test container template to create ready to run Sakuli container, based on Sakuli S2I, using the previously
+defined S2I image stream, running the configured suite.
 
 ====== Advantages of Sakuli S2I
 Beside the general advantages of OpenShift S2I, Sakuli S2I adds additional ones in terms of test automation.
@@ -159,10 +157,8 @@ Beside the general advantages of OpenShift S2I, Sakuli S2I adds additional ones 
 * Reduces CI/CD pipeline processing time by just updating the suite in the sakuli container environment.
 
 ====== Modify the base image
-The
-link:docker/openshift/openshift.sakuli.s2i.build.yaml[Sakuli test container template]
-provides the possibility to exchange the base image of your Sakuli test environment, so that all available
-link:docs/manual/execution/containerized/docker-images.adoc[base images]
+The Sakuli test container template
+provides the possibility to exchange the base image of your Sakuli test environment, so that all available base images
 can be used.
 
 [source]

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -144,10 +144,10 @@ It's possible to use all the features of Sakuli combined with the power of
 https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[OpenShift S2I].
 This empowers you to create s2i base images configured as you desire. The only thing you have to do is to add your test
 suite to the runnable sakuli test environment by configuration. Please find an example
-git-link:{docker/openshift/openshift.sakuli.s2i.image.build.yaml}{git-view}[s2i build config template]
+link:docker/openshift/openshift.sakuli.s2i.image.build.yaml[s2i build config template]
 in our template section. This template will provide you a build config and a image stream containing the Sakuli S2I
 image, so that you can easily build up the Sakuli test container for your suites. In addition, we provide a
-git-link:{docker/openshift/openshift.sakuli.s2i.build.yaml}{git-view}[Sakuli test container template]
+link:docker/openshift/openshift.sakuli.s2i.build.yaml[Sakuli test container template]
 to create ready to run Sakuli container, based on Sakuli S2I, using the previously defined S2I image stream, running the
 configured suite.
 
@@ -159,7 +159,26 @@ Beside the general advantages of OpenShift S2I, Sakuli S2I adds additional ones 
 * Reduces CI/CD pipeline processing time by just updating the suite in the sakuli container environment.
 
 ====== Modify the base image
+The
+link:docker/openshift/openshift.sakuli.s2i.build.yaml[Sakuli test container template]
+provides the possibility to exchange the base image of your Sakuli test environment, so that all available
+link:docs/manual/execution/containerized/docker-images.adoc[base images]
+can be used.
 
+[source]
+----
+oc process -f openshift.sakuli.s2i.build.yaml -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce"
+----
+
+In terms that you have designed your own Sakuli base image, you're also able to define the Source where the image
+should be taken from.
+
+[source]
+----
+oc process -f openshift.sakuli.s2i.build.yaml -p "BASE_IMAGE=my-sakuli-ubuntu-openbox" -p "BASE_IMAGE_KIND=ImageStream"
+----
+
+The values available in the `BASE_IMAGE_KIND` correlate to the values of the `dockerStrategy.from.kind` definition.
 
 ===== Other useful commands
 

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -151,11 +151,13 @@ git-link:{docker/openshift/openshift.sakuli.s2i.build.yaml}{git-view}[Sakuli tes
 to create ready to run Sakuli container, based on Sakuli S2I, using the previously defined S2I image stream, running the
 configured suite.
 
-
 ====== Advantages of Sakuli S2I
+Beside the general advantages of OpenShift S2I, Sakuli S2I adds additional ones in terms of test automation.
 
+* Keep the test suites close to your applications code and reference the suits in the build config.
+* If the tests change, you just have to start a new build of your Sakuli test container.
+* Reduces CI/CD pipeline processing time by just updating the suite in the sakuli container environment.
 
-[[openshift-s2i-modify-base-image]]
 ====== Modify the base image
 
 

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -179,6 +179,20 @@ oc process -f openshift.sakuli.s2i.build.yaml -p "BASE_IMAGE=my-sakuli-ubuntu-op
 
 The values available in the `BASE_IMAGE_KIND` correlate to the values of the `dockerStrategy.from.kind` definition.
 
+====== Example workflow
+
+Setup your Sakuli-S2I image.
+[source]
+----
+oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=sakuli-ubuntu-xfce-s2i" -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce"
+----
+Add the test suite of your choice to the S2I image
+[source]
+----
+oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-customer-workflow" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=http://github.com/SoftwareCompany/SoftwareProduct" -p "TESTSUITE_CONTEXT_DIR=e2e/customer-workflow"
+----
+Run your test container `test-customer-workflow`
+
 ===== Other useful commands
 
 ====== Delete specific application or E2E test

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -138,6 +138,27 @@ volumes:
 ===== Job Config
 Currently OpenShift (Version 3.5) have no different behaviour as Kubernetes itself, so take a look at <<kubernetes-job-config>>.
 
+[[openshift-s2i]]
+===== OpenShift source to image (S2I)
+It's possible to use all the features of Sakuli combined with the power of
+https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[OpenShift S2I].
+This empowers you to create s2i base images configured as you desire. The only thing you have to do is to add your test
+suite to the runnable sakuli test environment by configuration. Please find an example
+git-link:{docker/openshift/openshift.sakuli.s2i.image.build.yaml}{git-view}[s2i build config template]
+in our template section. This template will provide you a build config and a image stream containing the Sakuli S2I
+image, so that you can easily build up the Sakuli test container for your suites. In addition, we provide a
+git-link:{docker/openshift/openshift.sakuli.s2i.build.yaml}{git-view}[Sakuli test container template]
+to create ready to run Sakuli container, based on Sakuli S2I, using the previously defined S2I image stream, running the
+configured suite.
+
+
+====== Advantages of Sakuli S2I
+
+
+[[openshift-s2i-modify-base-image]]
+====== Modify the base image
+
+
 ===== Other useful commands
 
 ====== Delete specific application or E2E test

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -143,11 +143,13 @@ Currently OpenShift (Version 3.5) have no different behaviour as Kubernetes itse
 It's possible to use all the features of Sakuli combined with the power of
 https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[OpenShift S2I].
 This empowers you to create s2i base images configured as you desire. The only thing you have to do is to add your test
-suite to the runnable sakuli test environment by configuration. Please find an example s2i build config template
+suite to the runnable sakuli test environment by configuration. Please find an example
+git-link:docker/openshift/openshift.sakuli.s2i.image.build.yaml[link-text="s2i build config template", mode="view", link-window="_blank"]
 in our template section. This template will provide you a build config and a image stream containing the Sakuli S2I
 image, so that you can easily build up the Sakuli test container for your suites. In addition, we provide a
-Sakuli test container template to create ready to run Sakuli container, based on Sakuli S2I, using the previously
-defined S2I image stream, running the configured suite.
+git-link:docker/openshift/openshift.sakuli.s2i.build.yaml[link-text="Sakuli test container template", mode="view", link-window="_blank"]
+to create ready to run Sakuli container, based on Sakuli S2I, using the previously defined S2I image stream, running the
+configured suite.
 
 ====== Advantages of Sakuli S2I
 Beside the general advantages of OpenShift S2I, Sakuli S2I adds additional ones in terms of test automation.
@@ -157,9 +159,10 @@ Beside the general advantages of OpenShift S2I, Sakuli S2I adds additional ones 
 * Reduces CI/CD pipeline processing time by just updating the suite in the sakuli container environment.
 
 ====== Modify the base image
-The Sakuli test container template
-provides the possibility to exchange the base image of your Sakuli test environment, so that all available base images
-can be used.
+The
+link:docker/openshift/openshift.sakuli.s2i.build.yaml[Sakuli test container template]
+provides the possibility to exchange the base image of your Sakuli test environment, so that all available
+<<docker-image-os-types>> can be used.
 
 [source]
 ----

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -191,7 +191,11 @@ Add the test suite of your choice to the S2I image
 ----
 oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-xfce" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=https://github.com/ConSol/sakuli.git" -p "TESTSUITE_CONTEXT_DIR=example_test_suites/example_xfce" | oc apply -f -
 ----
-Run your test container `test-customer-workflow`
+Run your test container `test-xfce`
+[source]
+----
+oc run test-xfce --image=<your-docker-registry-ip>:5000/<your-project>/test-xfce --restart=OnFailure
+----
 
 ===== Other useful commands
 

--- a/docs/manual/execution/containerized/openshift.adoc
+++ b/docs/manual/execution/containerized/openshift.adoc
@@ -184,12 +184,12 @@ The values available in the `BASE_IMAGE_KIND` correlate to the values of the `do
 Setup your Sakuli-S2I image.
 [source]
 ----
-oc process -f openshift.sakuli.s2i.image.build.yaml -p "IMAGE=sakuli-ubuntu-xfce-s2i" -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce" | oc apply -f -
+oc process -f openshift.sakuli.s2i.image.build.yaml -p "IMAGE=sakuli-ubuntu-xfce-s2i" -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce:dev" | oc apply -f -
 ----
 Add the test suite of your choice to the S2I image
 [source]
 ----
-oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-customer-workflow" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=http://github.com/SoftwareCompany/SoftwareProduct" -p "TESTSUITE_CONTEXT_DIR=e2e/customer-workflow" | oc apply -f -
+oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-xfce" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=https://github.com/ConSol/sakuli.git" -p "TESTSUITE_CONTEXT_DIR=example_test_suites/example_xfce" | oc apply -f -
 ----
 Run your test container `test-customer-workflow`
 
@@ -202,7 +202,7 @@ Run your test container `test-customer-workflow`
 oc process -f openshift.sakuli.example.pod.run.yaml -v E2E_TEST_NAME=single-job | oc delete --grace-period=5 -f -
 ----
 
-====== Delete all running pods and configs
+====== Delete all running pods and configsŷ
 
 [source]
 ----


### PR DESCRIPTION
Hi!

I implemented a S2I base image containing a configurable predefined Sakuli environment where a test suite can simply be added by creating a build config based on the mentioned S2I image. 

Therefore you'll find four major additions to the repository:
- The Sakuli S2I Dockerfile
- The S2I Scripts
- A build config template to create a Sakuli S2I image
- A build config template to create a ready to run Sakuli test container running the specified suite

Example workflow:
1. Setup your Sakuli-S2I image.
`oc process -f openshift.sakuli.s2i.image.build.yaml -p "IMAGE=sakuli-ubuntu-xfce-s2i" -p "BASE_IMAGE=consol/sakuli-ubuntu-xfce:dev" | oc apply -f -`
2. Add the test suite of your choice to the S2I image
`oc process -f openshift.sakuli.s2i.build.yaml -p "IMAGE=test-xfce" -p "BASE_IMAGE=sakuli-ubuntu-xfce-s2i" -p "TESTSUITE_REPOSITORY_URL=https://github.com/ConSol/sakuli.git" -p "TESTSUITE_CONTEXT_DIR=example_test_suites/example_xfce" | oc apply -f -`
3. Run your test container `test-xfce`
`oc run test-xfce --image=<your-docker-registry-ip>:5000/<your-project>/test-xfce --restart=OnFailure`

As you can see, you can reuse the sakuli-ubuntu-xfce-s2i for all suites which require such a setup.

I hope you find this helpful.
If you have any questions, do not hesitate to contact me.
BR,
Sven