### PR TITLE
(#336) Fixed entrypoint

### DIFF
--- a/docker/Dockerfile.sakuli.s2i
+++ b/docker/Dockerfile.sakuli.s2i
@@ -14,5 +14,6 @@ RUN chmod 775 /opt/sakuli/s2i/* && \
 
 USER 1000
 
+# Set ENTRYPOINT to an empty string, since S2I doesn't parse an empty tag correctly
 ENTRYPOINT [""]
 CMD ["/opt/sakuli/s2i/usage"]

--- a/docker/Dockerfile.sakuli.s2i
+++ b/docker/Dockerfile.sakuli.s2i
@@ -14,5 +14,5 @@ RUN chmod 775 /opt/sakuli/s2i/* && \
 
 USER 1000
 
-ENTRYPOINT []
+ENTRYPOINT [""]
 CMD ["/opt/sakuli/s2i/usage"]

--- a/docs/manual/execution/containerized/docker-images.adoc
+++ b/docs/manual/execution/containerized/docker-images.adoc
@@ -362,7 +362,7 @@ Depending on the Sahi proxy, Sakuli will break the HTTPS connections between the
 
 . Update the permissions to ensure that the files can be read by container user:
 
-    ~$ chmod a+rw ssl_files/
+    ~$ chmod -R a+rw ssl_files/
 
 . At least you have just to add the files to the correct place in Docker image `Dockerfile`:
 


### PR DESCRIPTION
Hi!

I've changed the entrypoint to `ENTRYPOINT [""]`. I tested the setup with OpenShift 3.10.0 which is the up to date version as of today.

BR,
Sven